### PR TITLE
Dodanie stopniowego ładowania Newsów i wydarzeń

### DIFF
--- a/GameHub/GameHub/Fragments/Fragment1.cs
+++ b/GameHub/GameHub/Fragments/Fragment1.cs
@@ -16,6 +16,10 @@ namespace GameHub.Fragments
 {
     public class Fragment1 : SupportFragment
     {
+
+        private List<string> list = new List<string>();
+        private RecyclerView.Adapter mAdapter;
+
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
@@ -30,27 +34,37 @@ namespace GameHub.Fragments
 
             RecyclerView recyclerView = inflater.Inflate(Resource.Layout.Fragment1, container, false) as RecyclerView;
 
-            SetUpRecyclerView(recyclerView);
+            GetRandomSubList(Friends.NickStrings, 12);  // dodanie 12 obiektów do listy 
+
+            var mLayoutManager = new LinearLayoutManager(recyclerView.Context);
+            var onScrollListener = new RecyclerViewOnScrollListener(mLayoutManager);
+            recyclerView.AddOnScrollListener(onScrollListener);
+            recyclerView.SetLayoutManager(mLayoutManager);
+            mAdapter = new SimpleStringRecyclerViewAdapter(recyclerView.Context, list, Activity.Resources);
+            recyclerView.SetAdapter(mAdapter);
+
+            // Dodanie nowych obiektów do listy po dojechaniu na dó³
+            onScrollListener.LoadMoreEvent += (object sender, EventArgs e) => {
+
+                GetRandomSubList(Friends.NickStrings, 5); // generowanie i dodanie noeych obiektów
+
+                mAdapter.NotifyDataSetChanged(); 
+            };
+            
             return recyclerView;
         }
 
-        private void SetUpRecyclerView(RecyclerView recyclerView)
-        {
-            var values = GetRandomSubList(Friends.NickStrings, 50);
 
-            recyclerView.SetLayoutManager(new LinearLayoutManager(recyclerView.Context));
-            recyclerView.SetAdapter(new SimpleStringRecyclerViewAdapter(recyclerView.Context, values, Activity.Resources));
-        }
-
-        private List<String> GetRandomSubList(List<string> items, int a)
+        private void GetRandomSubList(List<string> items, int a)
         {
-            List<string> list = new List<string>();
+            //List<string> list = new List<string>();
             Random random = new Random();
-            while (list.Count < a)
+            while (a > 0)
             {
                 list.Add(items[random.Next(items.Count)]);
+                a--;
             }
-            return list;
+            //return list;
         }
 
         public class SimpleStringRecyclerViewAdapter : RecyclerView.Adapter

--- a/GameHub/GameHub/Fragments/News.cs
+++ b/GameHub/GameHub/Fragments/News.cs
@@ -18,9 +18,7 @@ namespace GameHub.Fragments
     {
 
         private RecyclerView mRecyclerView;
-        private RecyclerView.LayoutManager mLayoutManager;
         private RecyclerView.Adapter mAdapter;
-
 
         public override void OnCreate(Bundle savedInstanceState)
         {
@@ -31,23 +29,46 @@ namespace GameHub.Fragments
         {
             // Use this to return your custom view for this Fragment
 
+            int iloscnewsow = 12; //Startowa iloœæ newsóe
             mRecyclerView = inflater.Inflate(Resource.Layout.Fragment1, container, false) as RecyclerView;
-            mLayoutManager = new LinearLayoutManager(mRecyclerView.Context);
+            var mLayoutManager = new LinearLayoutManager(mRecyclerView.Context);
+            mAdapter = new RecyclerAdapter(iloscnewsow);
+
+            var onScrollListener = new RecyclerViewOnScrollListener(mLayoutManager);
+
+            mRecyclerView.AddOnScrollListener(onScrollListener);
             mRecyclerView.SetLayoutManager(mLayoutManager);
-            mAdapter = new RecyclerAdapter();
             mRecyclerView.SetAdapter(mAdapter);
+
+            // £adowanie nastêpnych newsów po dojechaniu na sam dó³ listy newsów
+            onScrollListener.LoadMoreEvent += (object sender, EventArgs e) => {
+
+                iloscnewsow += 5;  // zwiêksz iloœc newsów o 5 w póŸniejszym czasie ³adowanie do listy nowych obiektów
+                
+                //mAdapter.NotifyDataSetChanged();
+                mAdapter = new RecyclerAdapter(iloscnewsow);
+                mRecyclerView.SetAdapter(mAdapter);
+                
+            };
 
             return mRecyclerView;
         }
 
         public class RecyclerAdapter : RecyclerView.Adapter
         {
-            public RecyclerAdapter()
+
+            public int liczba = 12;
+
+            public RecyclerAdapter(int ilosc)
             {
+
+                liczba = ilosc;
             }
 
             public class MyView : RecyclerView.ViewHolder
             {
+
+                public TextView mName { get; set; }
                 public MyView(View view) : base(view)
                 {
 
@@ -57,22 +78,33 @@ namespace GameHub.Fragments
             public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
             {
                 View row = LayoutInflater.From(parent.Context).Inflate(Resource.Layout.News, parent, false);
-                MyView view = new MyView(row) { };
+
+                TextView txtName = row.FindViewById<TextView>(Resource.Id.textViewNews3);
+
+
+                MyView view = new MyView(row) { mName = txtName };
                 return view;
             }
 
             public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
             {
                 MyView view = holder as MyView;
+
+                view.mName.Text = "15:" + Convert.ToString(10 + position);
             }
 
             public override int ItemCount
             {
-                get { return 12; }  //iloœæ newsów w przysz³oœci JakasListaNewsów.Count
+                get { return liczba; }  //iloœæ newsów w przysz³oœci JakasListaNewsów.Count
             }
-        }
 
+            public void Zmienilosc(int a)
+            {
+                liczba = a;
 
+            }
+
+        } 
 
     }
 }

--- a/GameHub/GameHub/Fragments/RecyclerViewOnScrollListener.cs
+++ b/GameHub/GameHub/Fragments/RecyclerViewOnScrollListener.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Android.Support.V7.Widget;
+using Android.App;
+using Android.Content;
+using System.Threading;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace GameHub.Fragments
+{
+    public class RecyclerViewOnScrollListener : RecyclerView.OnScrollListener
+    {
+        public delegate void LoadMoreEventHandler(object sender, EventArgs e);
+        public event LoadMoreEventHandler LoadMoreEvent;
+
+        private LinearLayoutManager LayoutManager;
+
+        public RecyclerViewOnScrollListener(LinearLayoutManager layoutManager)
+        {
+            LayoutManager = layoutManager;
+        }
+
+        public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
+        {
+            base.OnScrolled(recyclerView, dx, dy);
+
+            var visibleItemCount = recyclerView.ChildCount;
+            var totalItemCount = recyclerView.GetAdapter().ItemCount;
+            var pastVisiblesItems = LayoutManager.FindFirstVisibleItemPosition();
+
+            if ((visibleItemCount + pastVisiblesItems) >= totalItemCount)
+            {
+                Thread.Sleep(500);   // w póŸniejszym czasie wywaliæ bo nie potrzebnie opóŸnia ³adowanie !!
+                LoadMoreEvent(this, null);
+                LayoutManager.ScrollToPosition(pastVisiblesItems);
+            }
+        }
+    }
+}

--- a/GameHub/GameHub/GameHub.csproj
+++ b/GameHub/GameHub/GameHub.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="Fragments\Fragment1.cs" />
     <Compile Include="Fragments\News.cs" />
+    <Compile Include="Fragments\RecyclerViewOnScrollListener.cs" />
     <Compile Include="Lists\Friends.cs" />
     <Compile Include="LoginSystem.cs" />
     <Compile Include="MainActivity.cs" />
@@ -105,9 +106,14 @@
     <AndroidResource Include="Resources\layout\News.axml">
       <SubType>Designer</SubType>
     </AndroidResource>
-    <AndroidResource Include="Resources\layout\Fragment1.axml" />
+    <AndroidResource Include="Resources\layout\Fragment1.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
     <AndroidResource Include="Resources\layout\List_Item.axml" />
     <AndroidResource Include="Resources\layout\ViewPager.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include="Resources\layout\Logowanie.axml">
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>

--- a/GameHub/GameHub/MainActivity.cs
+++ b/GameHub/GameHub/MainActivity.cs
@@ -39,22 +39,6 @@ namespace GameHub
             SupportActionBar.SetDisplayHomeAsUpEnabled(true);
             SupportActionBar.Title = "Hub";
 
-
-            //Sławek
-            /* do wyświetlania newsów w recycler View
-  private RecyclerView mRecyclerView;
-  private RecyclerView.LayoutManager mLayoutManager;
-  private RecyclerView.Adapter mAdapter;
-
-mRecyclerView = FindViewById<RecyclerView>(Resource.Id.recyclerView);
-mLayoutManager = new LinearLayoutManager(this);
-mRecyclerView.SetLayoutManager(mLayoutManager);
-mAdapter = new RecyclerAdapter();
-mRecyclerView.SetAdapter(mAdapter);
- */
-
-
-
             mDrawerLayout = FindViewById<DrawerLayout>(Resource.Id.drawer_layout);
             NavigationView navigationView = FindViewById<NavigationView>(Resource.Id.nav_view);
 


### PR DESCRIPTION
żeby nie wszystko ładowało sie przy starcie dopiero po dojechaniu na sam
dół ładowane są nowe Newsy i "wydarzenia"

Jak klasa RecyclerViewOnScrollListener nie pasuje w Fragments to
przenieście gdzieś indziej